### PR TITLE
Add `PGPOOL_ENABLE_LOAD_BALANCING` environment setting

### DIFF
--- a/4/centos-7/docker-compose.yml
+++ b/4/centos-7/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - PGPOOL_POSTGRES_PASSWORD=adminpassword
       - PGPOOL_ADMIN_USERNAME=admin
       - PGPOOL_ADMIN_PASSWORD=adminpassword
+      - PGPOOL_ENABLE_LOAD_BALANCING=yes
 volumes:
   pg_0_data:
     driver: local

--- a/4/debian-9/docker-compose.yml
+++ b/4/debian-9/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - PGPOOL_POSTGRES_PASSWORD=adminpassword
       - PGPOOL_ADMIN_USERNAME=admin
       - PGPOOL_ADMIN_PASSWORD=adminpassword
+      - PGPOOL_ENABLE_LOAD_BALANCING=yes
 volumes:
   pg_0_data:
     driver: local

--- a/4/ol-7/docker-compose.yml
+++ b/4/ol-7/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       - PGPOOL_POSTGRES_PASSWORD=adminpassword
       - PGPOOL_ADMIN_USERNAME=admin
       - PGPOOL_ADMIN_PASSWORD=adminpassword
+      - PGPOOL_ENABLE_LOAD_BALANCING=yes
 volumes:
   pg_0_data:
     driver: local

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Pgpool:
 - `PGPOOL_SR_CHECK_PASSWORD_FILE`: Path to a file that contains the password to use to perform streaming checks. This will override the value specified in `PGPOOL_SR_CHECK_PASSWORD`. No defaults.
 - `PGPOOL_BACKEND_NODES`: Comma separated list of backend nodes in the cluster.  No defaults.
 - `PGPOOL_ENABLE_LDAP`: Whether to enable LDAP authentication. Defaults to `no`.
+- `PGPOOL_ENABLE_LOAD_BALANCING`: Whether to enable Load-Balancing mode. Defaults to `yes`.
 - `PGPOOL_POSTGRES_USERNAME`: Postgres administrator user name, this will be use to allow postgres admin authentication through Pgpool.
 - `PGPOOL_POSTGRES_PASSWORD`: Password for the user set in `PGPOOL_POSTGRES_USERNAME` environment variable. No defaults.
 - `PGPOOL_ADMIN_USERNAME`: Username for the pgpool administrator. No defaults.
@@ -408,6 +409,7 @@ Please see the list of environment variables available in the Bitnami Pgpool con
 | PGPOOL_ENABLE_LDAP                   | `no`                               |
 | PGPOOL_ADMIN_USERNAME=admin          | `nil`                              |
 | PGPOOL_ADMIN_PASSWORD=adminpassword  | `nil`                              |
+| PGPOOL_ENABLE_LOAD_BALANCING         | `yes`                              |
 
 
 # Logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
     ports:
       - 5432:5432
     environment:
+      - PGPOOL_ENABLE_LOAD_BALANCING=yes
       - PGPOOL_BACKEND_NODES=0:pg-0:5432,1:pg-1:5432
       - PGPOOL_SR_CHECK_USER=customuser
       - PGPOOL_SR_CHECK_PASSWORD=custompassword

--- a/test.yaml
+++ b/test.yaml
@@ -32,6 +32,8 @@ spec:
           value: "adminpassword"
         - name: PGPOOL_ENABLE_LDAP
           value: "no"
+        - name: PGPOOL_ENABLE_LOAD_BALANCING
+          value: "yes"
         - name: PGPOOL_USERNAME
           values: "customuser"
         - name: PGPOOL_PASSWORD


### PR DESCRIPTION
**Description of the change**

Adding `PGPOOL_ENABLE_LOAD_BALANCING` environment setting. It sets `load_balance_mode` in `pgpool.conf`. The rationale is to be able to NOT use load balancing when it's not needed.

**Benefits**

In a setup where scaling / Load-Balancing is not needed, this setting is quite useful as solves potential data consistency issues. E.g. PostgreSQL HA Helm setup where we need only replication working and routing to the current primary.

**Possible drawbacks**

Can't think of any, since the previous behaviour persists - by default Load-Balancing is `on`.

**Applicable issues**

\-

**Additional information**

After thing change I can proceed with updates to PostgreSQL HA Helm chart to support switching of the Load-Balancing.
