### PR TITLE
Add some PGPOOL_* directives with default values

### DIFF
--- a/4/debian-10/rootfs/libpgpool.sh
+++ b/4/debian-10/rootfs/libpgpool.sh
@@ -143,8 +143,8 @@ pgpool_validate() {
         print_validation_error "pool_hba.conf authentication and pool password should be enabled for LDAP to work. Keep the PGPOOL_ENABLE_POOL_HBA and PGPOOL_ENABLE_POOL_PASSWD environment variables set to 'yes'."
     fi
 
-    if [[ -z "$PGPOOL_POSTGRES_USERNAME" ]] || [[ -z "$PGPOOL_POSTGRES_PASSWORD" ]]; then
-        print_validation_error "The administrator's database credentials are required. Set the environment variables PGPOOL_POSTGRES_USERNAME and PGPOOL_POSTGRES_PASSWORD with the administrator's database credentials."
+    if  is_boolean_yes "$PGPOOL_ENABLE_POOL_PASSWD" && ([[ -z "$PGPOOL_POSTGRES_USERNAME" ]] || [[ -z "$PGPOOL_POSTGRES_PASSWORD" ]]); then
+      print_validation_error "The administrator's database credentials are required. Set the environment variables PGPOOL_POSTGRES_USERNAME and PGPOOL_POSTGRES_PASSWORD with the administrator's database credentials."
     fi
 
     if [[ -z "$PGPOOL_BACKEND_NODES" ]]; then

--- a/4/debian-10/rootfs/libpgpool.sh
+++ b/4/debian-10/rootfs/libpgpool.sh
@@ -122,7 +122,7 @@ pgpool_validate() {
     }
 
     if ! is_yes_no_value "$PGPOOL_ENABLE_POOL_HBA"; then
-        print_validation_error "The values allowed for PGPOOL_ENABLE_LOAD_BALANCING are: yes or no"
+        print_validation_error "The values allowed for PGPOOL_ENABLE_POOL_HBA are: yes or no"
     fi
 
     if ! is_yes_no_value "$PGPOOL_ENABLE_POOL_PASSWD"; then
@@ -139,12 +139,12 @@ pgpool_validate() {
         print_validation_error "The LDAP configuration is required when LDAP authentication is enabled. Set the environment variables PGPOOL_LDAP_URI, PGPOOL_LDAP_BASE, PGPOOL_LDAP_BIND_DN and PGPOOL_LDAP_BIND_PASSWORD with the LDAP configuration."
     fi
 
-    if is_boolean_yes "$PGPOOL_ENABLE_POOL_PASSWD"; then
-        if [[ -z "$PGPOOL_POSTGRES_USERNAME" ]] || [[ -z "$PGPOOL_POSTGRES_PASSWORD" ]]; then
-            print_validation_error "The administrator's database credentials are required. Set the environment variables PGPOOL_POSTGRES_USERNAME and PGPOOL_POSTGRES_PASSWORD with the administrator's database credentials."
-        fi
-    else
-        info "Skip generating administrator's credentials due to PGPOOL_ENABLE_POOL_PASSWD = no"
+    if is_boolean_yes "$PGPOOL_ENABLE_LDAP" && ( ! is_boolean_yes "$PGPOOL_ENABLE_POOL_HBA" || ! is_boolean_yes "$PGPOOL_ENABLE_POOL_PASSWD" ); then
+        print_validation_error "pool_hba.conf authentication and pool password should be enabled for LDAP to work. Keep the PGPOOL_ENABLE_POOL_HBA and PGPOOL_ENABLE_POOL_PASSWD environment variables set to 'yes'."
+    fi
+
+    if [[ -z "$PGPOOL_POSTGRES_USERNAME" ]] || [[ -z "$PGPOOL_POSTGRES_PASSWORD" ]]; then
+        print_validation_error "The administrator's database credentials are required. Set the environment variables PGPOOL_POSTGRES_USERNAME and PGPOOL_POSTGRES_PASSWORD with the administrator's database credentials."
     fi
 
     if [[ -z "$PGPOOL_BACKEND_NODES" ]]; then
@@ -174,7 +174,7 @@ pgpool_attach_node() {
     info "Attaching backend node..."
     export PCPPASSFILE=$(mktemp /tmp/pcppass-XXXXX)
     echo "localhost:9898:${PGPOOL_ADMIN_USERNAME}:${PGPOOL_ADMIN_PASSWORD}" > "${PCPPASSFILE}"
-    pcp_attach_node -h localhost  -U "${PGPOOL_ADMIN_USERNAME}" -p 9898 -n "${node_id}" -w
+    pcp_attach_node -h localhost -U "${PGPOOL_ADMIN_USERNAME}" -p 9898 -n "${node_id}" -w
     rm -rf "${PCPPASSFILE}"
 }
 
@@ -225,14 +225,17 @@ pgpool_start_nslcd_bg() {
 #########################
 pgpool_create_pghba() {
     local authentication="md5"
+    local postgres_auth_line=""
     info "Generating pg_hba.conf file..."
 
     is_boolean_yes "$PGPOOL_ENABLE_LDAP" && authentication="pam pamservice=pgpool.pam"
-
+    if is_boolean_yes "$PGPOOL_ENABLE_POOL_PASSWD"; then
+        postgres_auth_line="host     all             ${PGPOOL_POSTGRES_USERNAME}       all         md5"
+    fi
     cat > "$PGPOOL_PGHBA_FILE" << EOF
 local    all             all                            trust
 host     all             $PGPOOL_SR_CHECK_USER       all         trust
-host     all             $PGPOOL_POSTGRES_USERNAME       all         md5
+$postgres_auth_line
 host     all             wide               all         trust
 host     all             pop_user           all         trust
 host     all             all                all         $authentication
@@ -302,9 +305,9 @@ EOF
 pgpool_create_config() {
     local -i node_counter=0
     local load_balance_mode=""
+    local pool_hba=""
+    local pool_passwd=""
     local allow_clear_text_frontend_auth="off"
-    local pool_hba="on"
-    local pool_passwd="pool_passwd"
 
     if is_boolean_yes "$PGPOOL_ENABLE_LOAD_BALANCING"; then
         load_balance_mode="on"
@@ -331,7 +334,6 @@ pgpool_create_config() {
         # ref: https://www.pgpool.net/docs/latest/en/html/runtime-config-connection.html#GUC-POOL-PASSWD
         pool_passwd=""
     fi
-
 
     info "Generating pgpool.conf file..."
     # Configuring Pgpool-II to use the streaming replication mode since it's the recommended way
@@ -447,13 +449,12 @@ EOF
 #   None
 #########################
 pgpool_generate_password_file() {
-
     if is_boolean_yes "$PGPOOL_ENABLE_POOL_PASSWD"; then
         info "Generating password file for local authentication..."
 
         pg_md5 -m --config-file="$PGPOOL_CONF_FILE" -u "$PGPOOL_POSTGRES_USERNAME" "$PGPOOL_POSTGRES_PASSWORD"
     else
-        info "Skip generating password file due to PGPOOL_ENABLE_POOL_PASSWD = no ..."
+        info "Skip generating password file due to PGPOOL_ENABLE_POOL_PASSWD = no"
     fi
 }
 

--- a/4/debian-10/rootfs/libpgpool.sh
+++ b/4/debian-10/rootfs/libpgpool.sh
@@ -302,6 +302,8 @@ pgpool_create_config() {
     local -i node_counter=0
     local load_balance_mode=""
     local allow_clear_text_frontend_auth="off"
+    local pool_hba="on"
+    local pool_passwd="pool_passwd"
 
     if is_boolean_yes "$PGPOOL_ENABLE_LOAD_BALANCING"; then
         load_balance_mode="on"

--- a/4/debian-10/rootfs/libpgpool.sh
+++ b/4/debian-10/rootfs/libpgpool.sh
@@ -41,7 +41,10 @@ export PGPOOL_PCP_CONF_FILE="${PGPOOL_ETC_DIR}/pcp.conf"
 export PGPOOL_PGHBA_FILE="${PGPOOL_CONF_DIR}/pool_hba.conf"
 export PGPOOL_PID_FILE="${PGPOOL_TMP_DIR}/pgpool.pid"
 export PGPOOL_LOG_FILE="${PGPOOL_LOG_DIR}/pgpool.log"
-export PGPOOL_PWD_FILE="pool_passwd"
+export PGPOOL_ENABLE_POOL_HBA="${PGPOOL_ENABLE_POOL_HBA:-yes}"
+export PGPOOL_ENABLE_POOL_PASSWD="${PGPOOL_ENABLE_POOL_PASSWD:-yes}"
+export PGPOOL_PASSWD_FILE="${PGPOOL_PASSWD_FILE:-pool_passwd}"
+export PGPOOL_MAX_POOL="${PGPOOL_MAX_POOL:-15}"
 export PATH="${PGPOOL_BIN_DIR}:$PATH"
 
 # Users
@@ -117,6 +120,14 @@ pgpool_validate() {
         error_code=1
     }
 
+    if ! is_yes_no_value "$PGPOOL_ENABLE_POOL_HBA"; then
+        print_validation_error "The values allowed for PGPOOL_ENABLE_LOAD_BALANCING are: yes or no"
+    fi
+
+    if ! is_yes_no_value "$PGPOOL_ENABLE_POOL_PASSWD"; then
+        print_validation_error "The values allowed for PGPOOL_ENABLE_POOL_PASSWD are: yes or no"
+    fi
+
     if [[ -z "$PGPOOL_ADMIN_USERNAME" ]] || [[ -z "$PGPOOL_ADMIN_PASSWORD" ]]; then
         print_validation_error "The Pgpool administrator user's credentials are mandatory. Set the environment variables PGPOOL_ADMIN_USERNAME and PGPOOL_ADMIN_PASSWORD with the Pgpool administrator user's credentials."
     fi
@@ -126,9 +137,15 @@ pgpool_validate() {
     if is_boolean_yes "$PGPOOL_ENABLE_LDAP" && ( [[ -z "${PGPOOL_LDAP_URI}" ]] || [[ -z "${PGPOOL_LDAP_BASE}" ]] || [[ -z "${PGPOOL_LDAP_BIND_DN}" ]] || [[ -z "${PGPOOL_LDAP_BIND_PASSWORD}" ]] ); then
         print_validation_error "The LDAP configuration is required when LDAP authentication is enabled. Set the environment variables PGPOOL_LDAP_URI, PGPOOL_LDAP_BASE, PGPOOL_LDAP_BIND_DN and PGPOOL_LDAP_BIND_PASSWORD with the LDAP configuration."
     fi
-    if [[ -z "$PGPOOL_POSTGRES_USERNAME" ]] || [[ -z "$PGPOOL_POSTGRES_PASSWORD" ]]; then
-        print_validation_error "The administrator's database credentials are required. Set the environment variables PGPOOL_POSTGRES_USERNAME and PGPOOL_POSTGRES_PASSWORD with the administrator's database credentials."
+
+    if is_boolean_yes "$PGPOOL_ENABLE_POOL_PASSWD"; then
+        if [[ -z "$PGPOOL_POSTGRES_USERNAME" ]] || [[ -z "$PGPOOL_POSTGRES_PASSWORD" ]]; then
+            print_validation_error "The administrator's database credentials are required. Set the environment variables PGPOOL_POSTGRES_USERNAME and PGPOOL_POSTGRES_PASSWORD with the administrator's database credentials."
+        fi
+    else
+        info "Skip generating administrator's credentials due to PGPOOL_ENABLE_POOL_PASSWD = no"
     fi
+
     if [[ -z "$PGPOOL_BACKEND_NODES" ]]; then
         print_validation_error "The list of backend nodes cannot be empty. Set the environment variable PGPOOL_BACKEND_NODES with a comma separated list of backend nodes."
     else
@@ -210,6 +227,7 @@ pgpool_create_pghba() {
     info "Generating pg_hba.conf file..."
 
     is_boolean_yes "$PGPOOL_ENABLE_LDAP" && authentication="pam pamservice=pgpool.pam"
+
     cat > "$PGPOOL_PGHBA_FILE" << EOF
 local    all             all                            trust
 host     all             $PGPOOL_SR_CHECK_USER       all         trust
@@ -283,12 +301,34 @@ EOF
 pgpool_create_config() {
     local -i node_counter=0
     local load_balance_mode=""
+    local allow_clear_text_frontend_auth="off"
 
     if is_boolean_yes "$PGPOOL_ENABLE_LOAD_BALANCING"; then
         load_balance_mode="on"
     else
         load_balance_mode="off"
     fi
+
+    if is_boolean_yes "$PGPOOL_ENABLE_POOL_HBA"; then
+        pool_hba="on"
+    else
+        pool_hba="off"
+    fi
+
+    if is_boolean_yes "$PGPOOL_ENABLE_POOL_PASSWD"; then
+        pool_passwd="$PGPOOL_PASSWD_FILE"
+    else
+        if ! is_boolean_yes "$PGPOOL_ENABLE_POOL_HBA"; then
+          # allow_clear_text_frontend_auth only works when enable_pool_hba is not enabled
+          # ref: https://www.pgpool.net/docs/latest/en/html/runtime-config-connection.html#GUC-ALLOW-CLEAR-TEXT-FRONTEND-AUTH
+          allow_clear_text_frontend_auth="on"
+        fi
+
+        # Specifying '' (empty) disables the use of password file.
+        # ref: https://www.pgpool.net/docs/latest/en/html/runtime-config-connection.html#GUC-POOL-PASSWD
+        pool_passwd=""
+    fi
+
 
     info "Generating pgpool.conf file..."
     # Configuring Pgpool-II to use the streaming replication mode since it's the recommended way
@@ -304,12 +344,13 @@ pgpool_create_config() {
     pgpool_set_property "pcp_socket_dir" "$PGPOOL_TMP_DIR"
     # Authentication settings
     # ref: http://www.pgpool.net/docs/latest/en/html/runtime-config-connection.html#RUNTIME-CONFIG-AUTHENTICATION-SETTINGS
-    pgpool_set_property "enable_pool_hba" "on"
-    pgpool_set_property "pool_passwd" "$PGPOOL_PWD_FILE"
+    pgpool_set_property "enable_pool_hba" "$pool_hba"
+    pgpool_set_property "allow_clear_text_frontend_auth" "$allow_clear_text_frontend_auth"
+    pgpool_set_property "pool_passwd" "$pool_passwd"
     pgpool_set_property "authentication_timeout" "30"
     # Connection Pooling settings
     # http://www.pgpool.net/docs/latest/en/html/runtime-config-connection-pooling.html
-    pgpool_set_property "max_pool" "15"
+    pgpool_set_property "max_pool" "$PGPOOL_MAX_POOL"
     # File Locations settings
     pgpool_set_property "pid_file_name" "$PGPOOL_PID_FILE"
     pgpool_set_property "logdir" "$PGPOOL_LOG_DIR"
@@ -403,9 +444,14 @@ EOF
 #   None
 #########################
 pgpool_generate_password_file() {
-    info "Generating password file for local authentication..."
 
-    pg_md5 -m --config-file="$PGPOOL_CONF_FILE" -u "$PGPOOL_POSTGRES_USERNAME" "$PGPOOL_POSTGRES_PASSWORD"
+    if is_boolean_yes "$PGPOOL_ENABLE_POOL_PASSWD"; then
+        info "Generating password file for local authentication..."
+
+        pg_md5 -m --config-file="$PGPOOL_CONF_FILE" -u "$PGPOOL_POSTGRES_USERNAME" "$PGPOOL_POSTGRES_PASSWORD"
+    else
+        info "Skip generating password file due to PGPOOL_ENABLE_POOL_PASSWD = no ..."
+    fi
 }
 
 ########################

--- a/4/ol-7/rootfs/libpgpool.sh
+++ b/4/ol-7/rootfs/libpgpool.sh
@@ -41,7 +41,10 @@ export PGPOOL_PCP_CONF_FILE="${PGPOOL_ETC_DIR}/pcp.conf"
 export PGPOOL_PGHBA_FILE="${PGPOOL_CONF_DIR}/pool_hba.conf"
 export PGPOOL_PID_FILE="${PGPOOL_TMP_DIR}/pgpool.pid"
 export PGPOOL_LOG_FILE="${PGPOOL_LOG_DIR}/pgpool.log"
-export PGPOOL_PWD_FILE="pool_passwd"
+export PGPOOL_ENABLE_POOL_HBA="${PGPOOL_ENABLE_POOL_HBA:-yes}"
+export PGPOOL_ENABLE_POOL_PASSWD="${PGPOOL_ENABLE_POOL_PASSWD:-yes}"
+export PGPOOL_PASSWD_FILE="${PGPOOL_PASSWD_FILE:-pool_passwd}"
+export PGPOOL_MAX_POOL="${PGPOOL_MAX_POOL:-15}"
 export PATH="${PGPOOL_BIN_DIR}:$PATH"
 
 # Users
@@ -117,6 +120,14 @@ pgpool_validate() {
         error_code=1
     }
 
+    if ! is_yes_no_value "$PGPOOL_ENABLE_POOL_HBA"; then
+        print_validation_error "The values allowed for PGPOOL_ENABLE_LOAD_BALANCING are: yes or no"
+    fi
+
+    if ! is_yes_no_value "$PGPOOL_ENABLE_POOL_PASSWD"; then
+        print_validation_error "The values allowed for PGPOOL_ENABLE_POOL_PASSWD are: yes or no"
+    fi
+
     if [[ -z "$PGPOOL_ADMIN_USERNAME" ]] || [[ -z "$PGPOOL_ADMIN_PASSWORD" ]]; then
         print_validation_error "The Pgpool administrator user's credentials are mandatory. Set the environment variables PGPOOL_ADMIN_USERNAME and PGPOOL_ADMIN_PASSWORD with the Pgpool administrator user's credentials."
     fi
@@ -126,9 +137,15 @@ pgpool_validate() {
     if is_boolean_yes "$PGPOOL_ENABLE_LDAP" && ( [[ -z "${PGPOOL_LDAP_URI}" ]] || [[ -z "${PGPOOL_LDAP_BASE}" ]] || [[ -z "${PGPOOL_LDAP_BIND_DN}" ]] || [[ -z "${PGPOOL_LDAP_BIND_PASSWORD}" ]] ); then
         print_validation_error "The LDAP configuration is required when LDAP authentication is enabled. Set the environment variables PGPOOL_LDAP_URI, PGPOOL_LDAP_BASE, PGPOOL_LDAP_BIND_DN and PGPOOL_LDAP_BIND_PASSWORD with the LDAP configuration."
     fi
-    if [[ -z "$PGPOOL_POSTGRES_USERNAME" ]] || [[ -z "$PGPOOL_POSTGRES_PASSWORD" ]]; then
-        print_validation_error "The administrator's database credentials are required. Set the environment variables PGPOOL_POSTGRES_USERNAME and PGPOOL_POSTGRES_PASSWORD with the administrator's database credentials."
+
+    if is_boolean_yes "$PGPOOL_ENABLE_POOL_PASSWD"; then
+        if [[ -z "$PGPOOL_POSTGRES_USERNAME" ]] || [[ -z "$PGPOOL_POSTGRES_PASSWORD" ]]; then
+            print_validation_error "The administrator's database credentials are required. Set the environment variables PGPOOL_POSTGRES_USERNAME and PGPOOL_POSTGRES_PASSWORD with the administrator's database credentials."
+        fi
+    else
+        info "Skip generating postgres administrator's credentials due to PGPOOL_ENABLE_POOL_PASSWD = no"
     fi
+
     if [[ -z "$PGPOOL_BACKEND_NODES" ]]; then
         print_validation_error "The list of backend nodes cannot be empty. Set the environment variable PGPOOL_BACKEND_NODES with a comma separated list of backend nodes."
     else
@@ -210,6 +227,7 @@ pgpool_create_pghba() {
     info "Generating pg_hba.conf file..."
 
     is_boolean_yes "$PGPOOL_ENABLE_LDAP" && authentication="pam pamservice=pgpool.pam"
+
     cat > "$PGPOOL_PGHBA_FILE" << EOF
 local    all             all                            trust
 host     all             $PGPOOL_SR_CHECK_USER       all         trust
@@ -283,11 +301,32 @@ EOF
 pgpool_create_config() {
     local -i node_counter=0
     local load_balance_mode=""
+    local allow_clear_text_frontend_auth="off"
 
     if is_boolean_yes "$PGPOOL_ENABLE_LOAD_BALANCING"; then
         load_balance_mode="on"
     else
         load_balance_mode="off"
+    fi
+
+    if is_boolean_yes "$PGPOOL_ENABLE_POOL_HBA"; then
+        pool_hba="on"
+    else
+        pool_hba="off"
+    fi
+
+    if is_boolean_yes "$PGPOOL_ENABLE_POOL_PASSWD"; then
+        pool_passwd="$PGPOOL_PASSWD_FILE"
+    else
+        if ! is_boolean_yes "$PGPOOL_ENABLE_POOL_HBA"; then
+          # allow_clear_text_frontend_auth only works when enable_pool_hba is not enabled
+          # ref: https://www.pgpool.net/docs/latest/en/html/runtime-config-connection.html#GUC-ALLOW-CLEAR-TEXT-FRONTEND-AUTH
+          allow_clear_text_frontend_auth="on"
+        fi
+
+        # Specifying '' (empty) disables the use of password file.
+        # ref: https://www.pgpool.net/docs/latest/en/html/runtime-config-connection.html#GUC-POOL-PASSWD
+        pool_passwd=""
     fi
 
     info "Generating pgpool.conf file..."
@@ -304,12 +343,13 @@ pgpool_create_config() {
     pgpool_set_property "pcp_socket_dir" "$PGPOOL_TMP_DIR"
     # Authentication settings
     # ref: http://www.pgpool.net/docs/latest/en/html/runtime-config-connection.html#RUNTIME-CONFIG-AUTHENTICATION-SETTINGS
-    pgpool_set_property "enable_pool_hba" "on"
-    pgpool_set_property "pool_passwd" "$PGPOOL_PWD_FILE"
+    pgpool_set_property "enable_pool_hba" "$pool_hba"
+    pgpool_set_property "allow_clear_text_frontend_auth" "$allow_clear_text_frontend_auth"
+    pgpool_set_property "pool_passwd" "$pool_passwd"
     pgpool_set_property "authentication_timeout" "30"
     # Connection Pooling settings
     # http://www.pgpool.net/docs/latest/en/html/runtime-config-connection-pooling.html
-    pgpool_set_property "max_pool" "15"
+    pgpool_set_property "max_pool" "$PGPOOL_MAX_POOL"
     # File Locations settings
     pgpool_set_property "pid_file_name" "$PGPOOL_PID_FILE"
     pgpool_set_property "logdir" "$PGPOOL_LOG_DIR"
@@ -403,9 +443,14 @@ EOF
 #   None
 #########################
 pgpool_generate_password_file() {
-    info "Generating password file for local authentication..."
 
-    pg_md5 -m --config-file="$PGPOOL_CONF_FILE" -u "$PGPOOL_POSTGRES_USERNAME" "$PGPOOL_POSTGRES_PASSWORD"
+    if is_boolean_yes "$PGPOOL_ENABLE_POOL_PASSWD"; then
+        info "Generating password file for local authentication..."
+
+        pg_md5 -m --config-file="$PGPOOL_CONF_FILE" -u "$PGPOOL_POSTGRES_USERNAME" "$PGPOOL_POSTGRES_PASSWORD"
+    else
+        info "Skip generating password file due to PGPOOL_ENABLE_POOL_PASSWD = no ..."
+    fi
 }
 
 ########################

--- a/4/ol-7/rootfs/libpgpool.sh
+++ b/4/ol-7/rootfs/libpgpool.sh
@@ -143,7 +143,7 @@ pgpool_validate() {
         print_validation_error "pool_hba.conf authentication and pool password should be enabled for LDAP to work. Keep the PGPOOL_ENABLE_POOL_HBA and PGPOOL_ENABLE_POOL_PASSWD environment variables set to 'yes'."
     fi
 
-    if [[ -z "$PGPOOL_POSTGRES_USERNAME" ]] || [[ -z "$PGPOOL_POSTGRES_PASSWORD" ]]; then
+    if  is_boolean_yes "$PGPOOL_ENABLE_POOL_PASSWD" && ([[ -z "$PGPOOL_POSTGRES_USERNAME" ]] || [[ -z "$PGPOOL_POSTGRES_PASSWORD" ]]); then
         print_validation_error "The administrator's database credentials are required. Set the environment variables PGPOOL_POSTGRES_USERNAME and PGPOOL_POSTGRES_PASSWORD with the administrator's database credentials."
     fi
 

--- a/4/ol-7/rootfs/libpgpool.sh
+++ b/4/ol-7/rootfs/libpgpool.sh
@@ -302,6 +302,8 @@ pgpool_create_config() {
     local -i node_counter=0
     local load_balance_mode=""
     local allow_clear_text_frontend_auth="off"
+    local pool_hba="on"
+    local pool_passwd="pool_passwd"
 
     if is_boolean_yes "$PGPOOL_ENABLE_LOAD_BALANCING"; then
         load_balance_mode="on"

--- a/README.md
+++ b/README.md
@@ -435,6 +435,10 @@ Please see the list of environment variables available in the Bitnami Pgpool con
 | PGPOOL_ADMIN_USERNAME=admin          | `nil`                              |
 | PGPOOL_ADMIN_PASSWORD=adminpassword  | `nil`                              |
 | PGPOOL_ENABLE_LOAD_BALANCING         | `yes`                              |
+| PGPOOL_ENABLE_POOL_HBA               | `yes`                              |
+| PGPOOL_ENABLE_POOL_PASSWD            | `yes`                              |
+| PGPOOL_PASSWD_FILE                   | `pool_passwd`                      |
+| PGPOOL_MAX_POOL                      | `15`                               |
 
 # Logging
 

--- a/README.md
+++ b/README.md
@@ -235,9 +235,13 @@ Pgpool:
 - `PGPOOL_SR_CHECK_USER`: Username to use to perform streaming checks. No defaults.
 - `PGPOOL_SR_CHECK_PASSWORD`: Password to use to perform streaming checks. No defaults.
 - `PGPOOL_SR_CHECK_PASSWORD_FILE`: Path to a file that contains the password to use to perform streaming checks. This will override the value specified in `PGPOOL_SR_CHECK_PASSWORD`. No defaults.
-- `PGPOOL_BACKEND_NODES`: Comma separated list of backend nodes in the cluster.  No defaults.
+- `PGPOOL_BACKEND_NODES`: Comma separated list of backend nodes in the cluster. No defaults.
 - `PGPOOL_ENABLE_LDAP`: Whether to enable LDAP authentication. Defaults to `no`.
 - `PGPOOL_ENABLE_LOAD_BALANCING`: Whether to enable Load-Balancing mode. Defaults to `yes`.
+- `PGPOOL_ENABLE_POOL_HBA`: Whether to use the pool_hba.conf authentication. Defaults to `yes`.
+- `PGPOOL_ENABLE_POOL_PASSWD`: Whether to use a password file specified by `PGPOOL_PASSWD_FILE` for authentication. Defaults to `yes`.
+- `PGPOOL_PASSWD_FILE`: The password file for authentication. Defaults to `pool_passwd`.
+- `PGPOOL_MAX_POOL`: The maximum number of cached connections in each child process. Defaults to `15`.
 - `PGPOOL_POSTGRES_USERNAME`: Postgres administrator user name, this will be use to allow postgres admin authentication through Pgpool.
 - `PGPOOL_POSTGRES_PASSWORD`: Password for the user set in `PGPOOL_POSTGRES_USERNAME` environment variable. No defaults.
 - `PGPOOL_ADMIN_USERNAME`: Username for the pgpool administrator. No defaults.


### PR DESCRIPTION
**Description of the change**

The following environment directives have been added with default values;

PGPOOL_ENABLE_POOL_HBA=yes
PGPOOL_ENABLE_POOL_PASSWD=yes
PGPOOL_PASSWD_FILE=pool_passwd
PGPOOL_MAX_POOL=15

**Benefits**

disabling to use of pool_passwd file 
increase/decrease max_pool settings via environment variable

**Possible drawbacks**

---

Applicable issues

---

Additional information

----
