### PR TITLE
Make num_init_children configurable

### DIFF
--- a/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
+++ b/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
@@ -60,6 +60,7 @@ export PGPOOL_ADMIN_USERNAME="${PGPOOL_ADMIN_USERNAME:-}"
 export PGPOOL_ENABLE_LDAP="${PGPOOL_ENABLE_LDAP:-no}"
 export PGPOOL_TIMEOUT="360"
 export PGPOOL_ENABLE_LOAD_BALANCING="${PGPOOL_ENABLE_LOAD_BALANCING:-yes}"
+export PGPOOL_NUM_INIT_CHILDREN="${PGPOOL_NUM_INIT_CHILDREN:-32}"
 
 EOF
     if [[ -f "${PGPOOL_ADMIN_PASSWORD_FILE:-}" ]]; then
@@ -326,6 +327,7 @@ pgpool_create_config() {
     pgpool_set_property "listen_addresses" "*"
     pgpool_set_property "port" "$PGPOOL_PORT_NUMBER"
     pgpool_set_property "socket_dir" "$PGPOOL_TMP_DIR"
+    pgpool_set_property "num_init_children" "$PGPOOL_NUM_INIT_CHILDREN"
     # Communication Manager Connection settings
     pgpool_set_property "pcp_socket_dir" "$PGPOOL_TMP_DIR"
     # Authentication settings

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Pgpool:
 - `PGPOOL_ENABLE_POOL_PASSWD`: Whether to use a password file specified by `PGPOOL_PASSWD_FILE` for authentication. Defaults to `yes`.
 - `PGPOOL_PASSWD_FILE`: The password file for authentication. Defaults to `pool_passwd`.
 - `PGPOOL_MAX_POOL`: The maximum number of cached connections in each child process. Defaults to `15`.
+- `PGPOOL_NUM_INIT_CHILDREN`: The number of preforked Pgpool server processes. Default is `32`.
 - `PGPOOL_POSTGRES_USERNAME`: Postgres administrator user name, this will be use to allow postgres admin authentication through Pgpool.
 - `PGPOOL_POSTGRES_PASSWORD`: Password for the user set in `PGPOOL_POSTGRES_USERNAME` environment variable. No defaults.
 - `PGPOOL_ADMIN_USERNAME`: Username for the pgpool administrator. No defaults.
@@ -446,6 +447,7 @@ Please see the list of environment variables available in the Bitnami Pgpool con
 | PGPOOL_ENABLE_POOL_PASSWD            | `yes`                              |
 | PGPOOL_PASSWD_FILE                   | `pool_passwd`                      |
 | PGPOOL_MAX_POOL                      | `15`                               |
+| PGPOOL_NUM_INIT_CHILDREN             | `32`                               |
 
 # Logging
 


### PR DESCRIPTION
**Description of the change**
Add a new environment variable PGPOOL_NUM_INIT_CHILDREN that
sets the value of num_init_children parameter in pgpool.conf.

This parameter is described [here](https://www.pgpool.net/docs/latest/en/html/runtime-config-connection.html#GUC-NUM-INIT-CHILDREN)

**Benefits**
Allows users to use multiple simultaneous connections

**Possible drawbacks**
Pay attention on Postgres' `max_connections` (see docs above)

**Applicable issues**
Fixes: #14

**Additional information**
N/A