### PR TITLE
Enhance configuration options

### DIFF
--- a/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
+++ b/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
@@ -55,13 +55,20 @@ export PGPOOL_DAEMON_GROUP="pgpool"
 export PGPOOL_PORT_NUMBER="${PGPOOL_PORT_NUMBER:-5432}"
 export PGPOOL_BACKEND_NODES="${PGPOOL_BACKEND_NODES:-}"
 export PGPOOL_SR_CHECK_USER="${PGPOOL_SR_CHECK_USER:-}"
+export PGPOOL_SR_CHECK_PERIOD="${PGPOOL_SR_CHECK_PERIOD:-30}"
 export PGPOOL_POSTGRES_USERNAME="${PGPOOL_POSTGRES_USERNAME:-postgres}"
 export PGPOOL_ADMIN_USERNAME="${PGPOOL_ADMIN_USERNAME:-}"
 export PGPOOL_ENABLE_LDAP="${PGPOOL_ENABLE_LDAP:-no}"
 export PGPOOL_TIMEOUT="360"
 export PGPOOL_ENABLE_LOAD_BALANCING="${PGPOOL_ENABLE_LOAD_BALANCING:-yes}"
+export PGPOOL_ENABLE_STATEMENT_LOAD_BALANCING="${PGPOOL_ENABLE_STATEMENT_LOAD_BALANCING:-no}"
 export PGPOOL_DISABLE_LOAD_BALANCE_ON_WRITE="${PGPOOL_DISABLE_LOAD_BALANCE_ON_WRITE:-transaction}"
 export PGPOOL_NUM_INIT_CHILDREN="${PGPOOL_NUM_INIT_CHILDREN:-32}"
+export PGPOOL_HEALTH_CHECK_USER="${PGPOOL_HEALTH_CHECK_USER:-$PGPOOL_SR_CHECK_USER}"
+export PGPOOL_HEALTH_CHECK_PERIOD="${PGPOOL_HEALTH_CHECK_PERIOD:-30}"
+export PGPOOL_HEALTH_CHECK_TIMEOUT="${PGPOOL_HEALTH_CHECK_TIMEOUT:-10}"
+export PGPOOL_HEALTH_CHECK_MAX_RETRIES="${PGPOOL_HEALTH_CHECK_MAX_RETRIES:-5}"
+export PGPOOL_HEALTH_CHECK_RETRY_DELAY="${PGPOOL_HEALTH_CHECK_RETRY_DELAY:-5}"
 
 EOF
     if [[ -f "${PGPOOL_ADMIN_PASSWORD_FILE:-}" ]]; then
@@ -123,8 +130,11 @@ pgpool_validate() {
     if [[ -z "$PGPOOL_ADMIN_USERNAME" ]] || [[ -z "$PGPOOL_ADMIN_PASSWORD" ]]; then
         print_validation_error "The Pgpool administrator user's credentials are mandatory. Set the environment variables PGPOOL_ADMIN_USERNAME and PGPOOL_ADMIN_PASSWORD with the Pgpool administrator user's credentials."
     fi
-    if [[ -z "$PGPOOL_SR_CHECK_USER" ]] || [[ -z "$PGPOOL_SR_CHECK_PASSWORD" ]]; then
+    if [[ "$PGPOOL_SR_CHECK_PERIOD" -gt 0 ]] && ( [[ -z "$PGPOOL_SR_CHECK_USER" ]] || [[ -z "$PGPOOL_SR_CHECK_PASSWORD" ]] ); then
         print_validation_error "The PostrgreSQL replication credentials are mandatory. Set the environment variables PGPOOL_SR_CHECK_USER and PGPOOL_SR_CHECK_PASSWORD with the PostrgreSQL replication credentials."
+    fi
+    if [[ -z "$PGPOOL_HEALTH_CHECK_USER" ]] || [[ -z "$PGPOOL_HEALTH_CHECK_PASSWORD" ]]; then
+        print_validation_error "The PostrgreSQL health check credentials are mandatory. Set the environment variables PGPOOL_HEALTH_CHECK_USER and PGPOOL_SR_HEALTH_PASSWORD with the PostrgreSQL health check credentials."
     fi
     if is_boolean_yes "$PGPOOL_ENABLE_LDAP" && ( [[ -z "${LDAP_URI}" ]] || [[ -z "${LDAP_BASE}" ]] || [[ -z "${LDAP_BIND_DN}" ]] || [[ -z "${LDAP_BIND_PASSWORD}" ]] ); then
         print_validation_error "The LDAP configuration is required when LDAP authentication is enabled. Set the environment variables LDAP_URI, LDAP_BASE, LDAP_BIND_DN and LDAP_BIND_PASSWORD with the LDAP configuration."
@@ -154,6 +164,9 @@ pgpool_validate() {
     fi
     if ! is_yes_no_value "$PGPOOL_ENABLE_LOAD_BALANCING"; then
         print_validation_error "The values allowed for PGPOOL_ENABLE_LOAD_BALANCING are: yes or no"
+    fi
+    if ! is_yes_no_value "$PGPOOL_ENABLE_STATEMENT_LOAD_BALANCING"; then
+        print_validation_error "The values allowed for PGPOOL_ENABLE_STATEMENT_LOAD_BALANCING are: yes or no"
     fi
     if ! is_positive_int "$PGPOOL_NUM_INIT_CHILDREN"; then
 	    print_validation_error "The values allowed for PGPOOL_NUM_INIT_CHILDREN: integer greater than 0"	
@@ -214,15 +227,19 @@ pgpool_healthcheck() {
 pgpool_create_pghba() {
     local authentication="md5"
     local postgres_auth_line=""
+    local sr_check_auth_line=""
     info "Generating pg_hba.conf file..."
 
     is_boolean_yes "$PGPOOL_ENABLE_LDAP" && authentication="pam pamservice=pgpool"
     if is_boolean_yes "$PGPOOL_ENABLE_POOL_PASSWD"; then
         postgres_auth_line="host     all             ${PGPOOL_POSTGRES_USERNAME}       all         md5"
     fi
+    if [[ ! -z "$PGPOOL_SR_CHECK_USER" ]]; then
+        sr_check_auth_line="host     all             ${PGPOOL_SR_CHECK_USER}       all         trust"
+    fi
     cat > "$PGPOOL_PGHBA_FILE" << EOF
 local    all             all                            trust
-host     all             $PGPOOL_SR_CHECK_USER       all         trust
+$sr_check_auth_line
 $postgres_auth_line
 host     all             wide               all         trust
 host     all             pop_user           all         trust
@@ -293,6 +310,7 @@ EOF
 pgpool_create_config() {
     local -i node_counter=0
     local load_balance_mode=""
+    local statement_level_load_balance=""
     local pool_hba=""
     local pool_passwd=""
     local allow_clear_text_frontend_auth="off"
@@ -301,6 +319,12 @@ pgpool_create_config() {
         load_balance_mode="on"
     else
         load_balance_mode="off"
+    fi
+
+    if is_boolean_yes "$PGPOOL_ENABLE_STATEMENT_LOAD_BALANCING"; then
+        statement_level_load_balance="on"
+    else
+        statement_level_load_balance="off"
     fi
 
     if is_boolean_yes "$PGPOOL_ENABLE_POOL_HBA"; then
@@ -349,19 +373,23 @@ pgpool_create_config() {
     pgpool_set_property "pid_file_name" "$PGPOOL_PID_FILE"
     pgpool_set_property "logdir" "$PGPOOL_LOG_DIR"
     # Load Balancing settings
+    # https://www.pgpool.net/docs/latest/en/html/runtime-config-load-balancing.html
     pgpool_set_property "load_balance_mode" "$load_balance_mode"
     pgpool_set_property "black_function_list" "nextval,setval"
-    # Streaming settings
+    pgpool_set_property "statement_level_load_balance" "$statement_level_load_balance"
+    # Streaming Replication Check settings
+    # https://www.pgpool.net/docs/latest/en/html/runtime-streaming-replication-check.html
     pgpool_set_property "sr_check_user" "$PGPOOL_SR_CHECK_USER"
     pgpool_set_property "sr_check_password" "$PGPOOL_SR_CHECK_PASSWORD"
-    pgpool_set_property "sr_check_period" "30"
+    pgpool_set_property "sr_check_period" "$PGPOOL_SR_CHECK_PERIOD"
     # Healthcheck per node settings
-    pgpool_set_property "health_check_period" "30"
-    pgpool_set_property "health_check_timeout" "10"
-    pgpool_set_property "health_check_user" "$PGPOOL_SR_CHECK_USER"
-    pgpool_set_property "health_check_password" "$PGPOOL_SR_CHECK_PASSWORD"
-    pgpool_set_property "health_check_max_retries" "5"
-    pgpool_set_property "health_check_retry_delay" "5"
+    # https://www.pgpool.net/docs/latest/en/html/runtime-config-health-check.html
+    pgpool_set_property "health_check_period" "$PGPOOL_HEALTH_CHECK_PERIOD"
+    pgpool_set_property "health_check_timeout" "$PGPOOL_HEALTH_CHECK_TIMEOUT"
+    pgpool_set_property "health_check_user" "$PGPOOL_HEALTH_CHECK_USER"
+    pgpool_set_property "health_check_password" "$PGPOOL_HEALTH_CHECK_PASSWORD"
+    pgpool_set_property "health_check_max_retries" "$PGPOOL_HEALTH_CHECK_MAX_RETRIES"
+    pgpool_set_property "health_check_retry_delay" "$PGPOOL_HEALTH_CHECK_RETRY_DELAY"
     # Failover settings
     pgpool_set_property "failover_command" "echo \">>> Failover - that will initialize new primary node search!\""
     pgpool_set_property "failover_on_backend_error" "off"

--- a/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
+++ b/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
@@ -310,7 +310,7 @@ EOF
 pgpool_create_config() {
     local -i node_counter=0
     local load_balance_mode=""
-    local statement_level_load_balance=""
+    local statement_level_load_balance="off"
     local pool_hba=""
     local pool_passwd=""
     local allow_clear_text_frontend_auth="off"
@@ -321,11 +321,7 @@ pgpool_create_config() {
         load_balance_mode="off"
     fi
 
-    if is_boolean_yes "$PGPOOL_ENABLE_STATEMENT_LOAD_BALANCING"; then
-        statement_level_load_balance="on"
-    else
-        statement_level_load_balance="off"
-    fi
+    is_boolean_yes "$PGPOOL_ENABLE_STATEMENT_LOAD_BALANCING" && statement_level_load_balance="on"
 
     if is_boolean_yes "$PGPOOL_ENABLE_POOL_HBA"; then
         pool_hba="on"

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ A HA PostgreSQL cluster with Pgpool, [Streaming replication](https://www.postgre
 Pgpool:
 
 - `PGPOOL_PASSWORD_FILE`: Path to a file that contains the password for the custom user set in the `PGPOOL_USERNAME` environment variable. This will override the value specified in `PGPOOL_PASSWORD`. No defaults.
+- `PGPOOL_SR_CHECK_PERIOD`: Specifies the time interval in seconds to check the streaming replication delay. Defaults to `30`.
 - `PGPOOL_SR_CHECK_USER`: Username to use to perform streaming checks. No defaults.
 - `PGPOOL_SR_CHECK_PASSWORD`: Password to use to perform streaming checks. No defaults.
 - `PGPOOL_SR_CHECK_PASSWORD_FILE`: Path to a file that contains the password to use to perform streaming checks. This will override the value specified in `PGPOOL_SR_CHECK_PASSWORD`. No defaults.
@@ -241,6 +242,7 @@ Pgpool:
 - `PGPOOL_DISABLE_LOAD_BALANCE_ON_WRITE`: Specify load balance behavior after write queries appear ('off', 'transaction', 'trans_transaction', 'always'). Defaults to 'transaction'
 - `PGPOOL_NUM_INIT_CHILDREN`: The number of preforked Pgpool-II server processes.  num_init_children is also the concurrent connections limit to Pgpool-II from clients. Defaults to 32.
 - `PGPOOL_ENABLE_LOAD_BALANCING`: Whether to enable Load-Balancing mode. Defaults to `yes`.
+- `PGPOOL_ENABLE_STATEMENT_LOAD_BALANCING`:  Whether to decide the load balancing node for each read query. Defaults to `no`.
 - `PGPOOL_ENABLE_POOL_HBA`: Whether to use the pool_hba.conf authentication. Defaults to `yes`.
 - `PGPOOL_ENABLE_POOL_PASSWD`: Whether to use a password file specified by `PGPOOL_PASSWD_FILE` for authentication. Defaults to `yes`.
 - `PGPOOL_PASSWD_FILE`: The password file for authentication. Defaults to `pool_passwd`.
@@ -250,7 +252,11 @@ Pgpool:
 - `PGPOOL_POSTGRES_PASSWORD`: Password for the user set in `PGPOOL_POSTGRES_USERNAME` environment variable. No defaults.
 - `PGPOOL_ADMIN_USERNAME`: Username for the pgpool administrator. No defaults.
 - `PGPOOL_ADMIN_PASSWORD`: Password for the user set in `PGPOOL_ADMIN_USERNAME` environment variable. No defaults.
-
+- `PGPOOL_HEALTH_CHECK_USER`: Specifies the PostgreSQL user name to perform health check. Defaults to value set in `PGPOOL_SR_CHECK_USER`.
+- `PGPOOL_HEALTH_CHECK_PERIOD`: Specifies the interval between the health checks in seconds. Defaults to `30`.
+- `PGPOOL_HEALTH_CHECK_TIMEOUT`: Specifies the timeout in seconds to give up connecting to the backend PostgreSQL if the TCP connect does not succeed within this time. Defaults to `10`.
+- `PGPOOL_HEALTH_CHECK_MAX_RETRIES`: Specifies the maximum number of retries to do before giving up and initiating failover when health check fails. Defaults to `5`.
+- `PGPOOL_HEALTH_CHECK_RETRY_DELAY`: Specifies the amount of time in seconds to sleep between failed health check retries. Defaults to `5`.
 
 PostgreSQL with Replication Manager:
 


### PR DESCRIPTION
**Description of the change**
I would like to this image with Google Cloud SQL for Postgres. The configuration is in many ways similar to what is described in the [docs for AWS Aurora](https://www.pgpool.net/docs/latest/en/html/example-aurora.html). In order to allow changing/setting these configuration parameters easily I have extended the image as follows:
1. Add ability to disable SR checks, i.e. expose new env. variable `PGPOOL_HEALTH_CHECK_PERIOD`
2. Add ability to configure statement levels load-balancing, i.e. expose new env. variable `PGPOOL_ENABLE_STATEMENT_LOAD_BALANCING `
3. Separate SR check user from health check user
4. Add ability to configure health check parameters, i.e. adding new env. variables
`PGPOOL_HEALTH_CHECK_PERIOD`, `PGPOOL_SR_CHECK_USER` `PGPOOL_HEALTH_CHECK_TIMEOUT`, `PGPOOL_SR_CHECK_PASSWORD`, `PGPOOL_HEALTH_CHECK_USER`, `PGPOOL_HEALTH_CHECK_PASSWORD`, `PGPOOL_HEALTH_CHECK_MAX_RETRIES`, `PGPOOL_HEALTH_CHECK_RETRY_DELAY`

**Benefits**

Ability to tweak the config without overriding the whole configuration file.

**Possible drawbacks**

Do not know of any at the moment.

**Applicable issues**

Do not know of any at the moment.

**Additional information**

For backward compatibility `PGPOOL_SR_CHECK_USER` is set as a default value for the `PGPOOL_HEALTH_CHECK_USER`.