### PR TITLE
FIX: allow_clear_text_frontend_auth with pool_passwd to suppress warn…

### DIFF
--- a/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
+++ b/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
@@ -341,15 +341,15 @@ pgpool_create_config() {
     if is_boolean_yes "$PGPOOL_ENABLE_POOL_PASSWD"; then
         pool_passwd="$PGPOOL_PASSWD_FILE"
     else
-        if ! is_boolean_yes "$PGPOOL_ENABLE_POOL_HBA"; then
-          # allow_clear_text_frontend_auth only works when enable_pool_hba is not enabled
-          # ref: https://www.pgpool.net/docs/latest/en/html/runtime-config-connection.html#GUC-ALLOW-CLEAR-TEXT-FRONTEND-AUTH
-          allow_clear_text_frontend_auth="on"
-        fi
-
         # Specifying '' (empty) disables the use of password file.
         # ref: https://www.pgpool.net/docs/latest/en/html/runtime-config-connection.html#GUC-POOL-PASSWD
         pool_passwd=""
+    fi
+
+    if ! is_boolean_yes "$PGPOOL_ENABLE_POOL_HBA"; then
+      # allow_clear_text_frontend_auth only works when enable_pool_hba is not enabled
+      # ref: https://www.pgpool.net/docs/latest/en/html/runtime-config-connection.html#GUC-ALLOW-CLEAR-TEXT-FRONTEND-AUTH
+      allow_clear_text_frontend_auth="on"
     fi
 
     info "Generating pgpool.conf file..."


### PR DESCRIPTION
**Description of the change**

Allow allow_clear_text_frontend_auth be enabled if pool_passwd is still enabled

**Benefits**

It will suppress warnings like:
```
2020-07-29 15:06:37: pid 198: LOG:  using clear text authentication with frontend
2020-07-29 15:06:37: pid 198: DETAIL:  backend will still use md5 auth
2020-07-29 15:06:37: pid 198: HINT:  you can disable this behavior by setting allow_clear_text_frontend_auth to off
2020-07-29 15:06:37: pid 198: WARNING:  unable to get password, password file descriptor is NULL
```
