### PR TITLE
fixes the healthcheck command path 

### DIFF
--- a/4/debian-10/docker-compose.yml
+++ b/4/debian-10/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - PGPOOL_ADMIN_PASSWORD=adminpassword
       - PGPOOL_ENABLE_LOAD_BALANCING=yes
     healthcheck:
-      test: ["CMD", "/healthcheck.sh"]
+      test: ["CMD", "/opt/bitnami/scripts/pgpool/healthcheck.sh"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ services:
       - PGPOOL_ADMIN_USERNAME=admin
       - PGPOOL_ADMIN_PASSWORD=adminpassword
     healthcheck:
-      test: ["CMD", "/healthcheck.sh"]
+      test: ["CMD", "/opt/bitnami/scripts/pgpool/healthcheck.sh"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose-ldap.yml
+++ b/docker-compose-ldap.yml
@@ -53,7 +53,7 @@ services:
       - LDAP_BIND_DN=cn=admin,dc=example,dc=org
       - LDAP_BIND_PASSWORD=adminpassword
     healthcheck:
-      test: ["CMD", "/healthcheck.sh"]
+      test: ["CMD", "/opt/bitnami/scripts/pgpool/healthcheck.sh"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - PGPOOL_ADMIN_PASSWORD=adminpassword
       - PGPOOL_ENABLE_LOAD_BALANCING=yes
     healthcheck:
-      test: ["CMD", "/healthcheck.sh"]
+      test: ["CMD", "/opt/bitnami/scripts/pgpool/healthcheck.sh"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
For each docker-compose file, this pull-request changes the `/healthcheck.sh` command path to the absolute path `/opt/bitnami/scripts/pgpool/healthcheck.sh`. 

This fixes #24 