### PR TITLE
Add sr_check_database to pgpool configuration

### DIFF
--- a/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
+++ b/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
@@ -57,6 +57,7 @@ export PGPOOL_PORT_NUMBER="${PGPOOL_PORT_NUMBER:-5432}"
 export PGPOOL_BACKEND_NODES="${PGPOOL_BACKEND_NODES:-}"
 export PGPOOL_SR_CHECK_USER="${PGPOOL_SR_CHECK_USER:-}"
 export PGPOOL_SR_CHECK_PERIOD="${PGPOOL_SR_CHECK_PERIOD:-30}"
+export PGPOOL_SR_CHECK_DATABASE="${PGPOOL_SR_CHECK_DATABASE:-postgres}"
 export PGPOOL_POSTGRES_USERNAME="${PGPOOL_POSTGRES_USERNAME:-postgres}"
 export PGPOOL_ADMIN_USERNAME="${PGPOOL_ADMIN_USERNAME:-}"
 export PGPOOL_ENABLE_LDAP="${PGPOOL_ENABLE_LDAP:-no}"
@@ -433,6 +434,7 @@ pgpool_create_config() {
     pgpool_set_property "sr_check_user" "$PGPOOL_SR_CHECK_USER"
     pgpool_set_property "sr_check_password" "$PGPOOL_SR_CHECK_PASSWORD"
     pgpool_set_property "sr_check_period" "$PGPOOL_SR_CHECK_PERIOD"
+    pgpool_set_property "sr_check_database" "$PGPOOL_SR_CHECK_DATABASE"
     # Healthcheck per node settings
     # https://www.pgpool.net/docs/latest/en/html/runtime-config-health-check.html
     pgpool_set_property "health_check_period" "$PGPOOL_HEALTH_CHECK_PERIOD"

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Pgpool:
 - `PGPOOL_SR_CHECK_USER`: Username to use to perform streaming checks. No defaults.
 - `PGPOOL_SR_CHECK_PASSWORD`: Password to use to perform streaming checks. No defaults.
 - `PGPOOL_SR_CHECK_PASSWORD_FILE`: Path to a file that contains the password to use to perform streaming checks. This will override the value specified in `PGPOOL_SR_CHECK_PASSWORD`. No defaults.
+- `PGPOOL_SR_CHECK_DATABASE`: Database to use to perform streaming checks. Defaults to `postgres`.
 - `PGPOOL_BACKEND_NODES`: Comma separated list of backend nodes in the cluster. No defaults.
 - `PGPOOL_ENABLE_LDAP`: Whether to enable LDAP authentication. Defaults to `no`.
 - `PGPOOL_DISABLE_LOAD_BALANCE_ON_WRITE`: Specify load balance behavior after write queries appear ('off', 'transaction', 'trans_transaction', 'always'). Defaults to 'transaction'


### PR DESCRIPTION
Customize `sr_check_database` value in _pgpool.conf_ via env. variable.

[Here](https://www.pgpool.net/docs/latest/en/html/runtime-streaming-replication-check.html) you can find more info about this parameter:
> sr_check_database (string)
> Specifies the database to perform streaming replication delay checks. The default is "postgres".
> 
> This parameter can be changed by reloading the Pgpool-II configurations.

With the changes in this PR and using the default env. variable, this is the result of the _pgpool.conf_ file:
```
# - Streaming -

sr_check_period = '30'
                                   # Streaming replication check period
                                   # Disabled (0) by default
sr_check_user = 'customuser'
                                   # Streaming replication check user
                                   # This is neccessary even if you disable streaming
                                   # replication delay check by sr_check_period = 0
sr_check_password = 'custompassword'
                                   # Password for streaming replication check user
                                   # Leaving it empty will make Pgpool-II to first look for the
                                   # Password in pool_passwd file before using the empty password

sr_check_database = 'postgres'
                                   # Database name for streaming replication check
```

Fixes #36