### PR TITLE
feat: skip to create pg_hba.conf when injected

### DIFF
--- a/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
+++ b/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
@@ -289,6 +289,11 @@ pgpool_create_pghba() {
     local sr_check_auth_line=""
     info "Generating pg_hba.conf file..."
 
+    if ! is_file_writable "$PGPOOL_PGHBA_FILE"; then
+        info "Injected pg_hba.conf files found. Skipping to create default config file..."
+        return
+    fi
+
     is_boolean_yes "$PGPOOL_ENABLE_LDAP" && authentication="pam pamservice=pgpool"
     if is_boolean_yes "$PGPOOL_ENABLE_POOL_PASSWD"; then
         postgres_auth_line="host     all             ${PGPOOL_POSTGRES_USERNAME}       all         md5"


### PR DESCRIPTION
Signed-off-by: darteaga <darteaga@vmware.com>

**Description of the change**

When the user injects an already existing `pg_hba.conf` the container fails. A pre-check has been implemented so the user will be able to inject this configuration via `ConfigMap` or swarm service config.

**Benefits**

Users will be able to inject this configuration via `ConfigMap` or swarm service config.

**Possible drawbacks**

N/A

**Applicable issues**

- fixes #40 

**Additional information**

N/A
