### PR TITLE
Add support for auto_failback

### DIFF
--- a/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
+++ b/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
@@ -364,6 +364,7 @@ backend_port$num = $port
 backend_weight$num = $weight
 backend_data_directory$num = '$dir'
 backend_flag$num = '$flag'
+backend_application_name$num = '$host'
 EOF
 }
 

--- a/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
+++ b/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
@@ -57,6 +57,7 @@ export PGPOOL_BACKEND_NODES="${PGPOOL_BACKEND_NODES:-}"
 export PGPOOL_SR_CHECK_USER="${PGPOOL_SR_CHECK_USER:-}"
 export PGPOOL_SR_CHECK_PERIOD="${PGPOOL_SR_CHECK_PERIOD:-30}"
 export PGPOOL_SR_CHECK_DATABASE="${PGPOOL_SR_CHECK_DATABASE:-postgres}"
+export PGPOOL_AUTO_FAILBACK="${PGPOOL_AUTO_FAILBACK:-no}"
 export PGPOOL_POSTGRES_USERNAME="${PGPOOL_POSTGRES_USERNAME:-postgres}"
 export PGPOOL_ADMIN_USERNAME="${PGPOOL_ADMIN_USERNAME:-}"
 export PGPOOL_ENABLE_LDAP="${PGPOOL_ENABLE_LDAP:-no}"
@@ -182,7 +183,7 @@ pgpool_validate() {
         print_validation_error "The provided PGPOOL_USER_CONF_FILE: ${PGPOOL_USER_CONF_FILE} must exist."
     fi
 
-    local yes_no_values=("PGPOOL_ENABLE_POOL_HBA" "PGPOOL_ENABLE_POOL_PASSWD" "PGPOOL_ENABLE_LOAD_BALANCING" "PGPOOL_ENABLE_STATEMENT_LOAD_BALANCING" "PGPOOL_ENABLE_LOG_CONNECTIONS" "PGPOOL_ENABLE_LOG_HOSTNAME" "PGPOOL_ENABLE_LOG_PER_NODE_STATEMENT")
+    local yes_no_values=("PGPOOL_AUTO_FAILBACK" "PGPOOL_ENABLE_POOL_HBA" "PGPOOL_ENABLE_POOL_PASSWD" "PGPOOL_ENABLE_LOAD_BALANCING" "PGPOOL_ENABLE_STATEMENT_LOAD_BALANCING" "PGPOOL_ENABLE_LOG_CONNECTIONS" "PGPOOL_ENABLE_LOG_HOSTNAME" "PGPOOL_ENABLE_LOG_PER_NODE_STATEMENT")
     for yn in "${yes_no_values[@]}"; do
         if ! is_yes_no_value "${!yn}"; then
             print_validation_error "The values allowed for $yn are: yes or no"
@@ -407,6 +408,8 @@ pgpool_create_config() {
     [[ -n "${PGPOOL_CHILD_LIFE_TIME:-}" ]] && pgpool_set_property "child_life_time" "$PGPOOL_CHILD_LIFE_TIME"
     [[ -n "${PGPOOL_CONNECTION_LIFE_TIME:-}" ]] && pgpool_set_property "connection_life_time" "$PGPOOL_CONNECTION_LIFE_TIME"
     [[ -n "${PGPOOL_CLIENT_IDLE_LIMIT-}" ]] && pgpool_set_property "client_idle_limit" "$PGPOOL_CLIENT_IDLE_LIMIT"
+    # Auto-failback
+    pgpool_set_property "auto_failback" "$(is_boolean_yes "$PGPOOL_AUTO_FAILBACK" && echo "on" || echo "off")"
     # Logging settings
     # https://www.pgpool.net/docs/latest/en/html/runtime-config-logging.html
     pgpool_set_property "log_connections" "$(is_boolean_yes "$PGPOOL_ENABLE_LOG_CONNECTIONS" && echo "on" || echo "off")"

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Pgpool configuration:
 - `PGPOOL_SR_CHECK_PASSWORD`: Password to use to perform streaming checks. No defaults.
 - `PGPOOL_SR_CHECK_PASSWORD_FILE`: Path to a file that contains the password to use to perform streaming checks. This will override the value specified in `PGPOOL_SR_CHECK_PASSWORD`. No defaults.
 - `PGPOOL_SR_CHECK_DATABASE`: Database to use to perform streaming checks. Defaults to `postgres`.
+- `PGPOOL_AUTO_FAILBACK`: Whether to automatically try to reconnect to down nodes. Defaults to `no`.
 - `PGPOOL_BACKEND_NODES`: Comma separated list of backend nodes in the cluster. No defaults.
 - `PGPOOL_ENABLE_LDAP`: Whether to enable LDAP authentication. Defaults to `no`.
 - `PGPOOL_DISABLE_LOAD_BALANCE_ON_WRITE`: Specify load balance behavior after write queries appear ('off', 'transaction', 'trans_transaction', 'always'). Defaults to 'transaction'


### PR DESCRIPTION
**Description of the change**

Since pgpool version 4.1, a new option, `auto_failback` is available which allows pgpool to attempt to reconnect to previously failed nodes automatically. See https://www.pgpool.net/docs/latest/en/html/runtime-config-failover.html#GUC-AUTO-FAILBACK

This PR introduces an environment variable to enable auto_failback. Additionally, for this feature to work correctly we also need to set `backend_application_name<X>` in configuration, otherwise pgpool cannot correctly determine streaming status. See https://www.sraoss.jp/pipermail/pgpool-general/2020-July/007227.html. Therefore we also set the `backend_application_name<X>` fields to match the backend's hostname, which is typical for a docker setup and works well with bitnami/postgresql-repmgr.

**Benefits**

The new `auto_failback` option can be made to work. Additionally, pgpool can correctly show standby nodes' streaming replication state (e.g. in `show pool_nodes`), previously this was blank.

**Possible drawbacks**

* May be incompatible with pgpool < 4.1
* Some users might need the ability to set `backend_application_name<X>` to values other than the backend's hostname. If this is the case, we can add an explicit application name as another parameter to the `:`-separated list of parameters passed for each backend.

**Applicable issues**

N/A

**Additional information**

N/A
