### PR TITLE
Add support for overwriting pool_hba.conf

### DIFF
--- a/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
+++ b/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
@@ -44,6 +44,7 @@ export PGPOOL_LOG_FILE="${PGPOOL_LOG_DIR}/pgpool.log"
 export PGPOOL_ENABLE_POOL_HBA="${PGPOOL_ENABLE_POOL_HBA:-yes}"
 export PGPOOL_ENABLE_POOL_PASSWD="${PGPOOL_ENABLE_POOL_PASSWD:-yes}"
 export PGPOOL_USER_CONF_FILE="${PGPOOL_USER_CONF_FILE:-}"
+export PGPOOL_USER_HBA_FILE="${PGPOOL_USER_HBA_FILE:-}"
 export PGPOOL_PASSWD_FILE="${PGPOOL_PASSWD_FILE:-pool_passwd}"
 export PATH="${PGPOOL_BIN_DIR}:$PATH"
 
@@ -193,6 +194,10 @@ pgpool_validate() {
 
     if [[ -n "$PGPOOL_USER_CONF_FILE" && ! -e "$PGPOOL_USER_CONF_FILE" ]]; then
         print_validation_error "The provided PGPOOL_USER_CONF_FILE: ${PGPOOL_USER_CONF_FILE} must exist."
+    fi
+
+    if [[ -n "$PGPOOL_USER_HBA_FILE" && ! -e "$PGPOOL_USER_HBA_FILE" ]]; then
+        print_validation_error "The provided PGPOOL_USER_HBA_FILE: ${PGPOOL_USER_HBA_FILE} must exist."
     fi
 
     local yes_no_values=("PGPOOL_ENABLE_POOL_HBA" "PGPOOL_ENABLE_POOL_PASSWD" "PGPOOL_ENABLE_LOAD_BALANCING" "PGPOOL_ENABLE_STATEMENT_LOAD_BALANCING" "PGPOOL_ENABLE_LOG_CONNECTIONS" "PGPOOL_ENABLE_LOG_HOSTNAME" "PGPOOL_ENABLE_LOG_PER_NODE_STATEMENT" "PGPOOL_AUTO_FAILBACK")
@@ -497,6 +502,11 @@ pgpool_create_config() {
     if [[ -f "$PGPOOL_USER_CONF_FILE" ]]; then
         info "Custom configuration '$PGPOOL_USER_CONF_FILE' detected!. Adding it to the configuration file."
         cat "$PGPOOL_USER_CONF_FILE" >>"$PGPOOL_CONF_FILE"
+    fi
+
+    if [[ -f "$PGPOOL_USER_HBA_FILE" ]]; then
+        info "Custom configuration '$PGPOOL_USER_HBA_FILE' detected!. Overwriting the generated hba file."
+        cat "$PGPOOL_USER_HBA_FILE" >"$PGPOOL_PGHBA_FILE"
     fi
 }
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,8 @@ Pgpool configuration:
 - `PGPOOL_HEALTH_CHECK_TIMEOUT`: Specifies the timeout in seconds to give up connecting to the backend PostgreSQL if the TCP connect does not succeed within this time. Defaults to `10`.
 - `PGPOOL_HEALTH_CHECK_MAX_RETRIES`: Specifies the maximum number of retries to do before giving up and initiating failover when health check fails. Defaults to `5`.
 - `PGPOOL_HEALTH_CHECK_RETRY_DELAY`: Specifies the amount of time in seconds to sleep between failed health check retries. Defaults to `5`.
-- `PGPOOL_USER_CONF_FILE`: Configuration file to be added to the generated config file. This allow to override configuration set by the initializacion process. No defaults.
+- `PGPOOL_USER_CONF_FILE`: Configuration file to be added to the generated config file. This allow to override configuration set by the initialization process. No defaults.
+- `PGPOOL_USER_HBA_FILE`: Configuration file to be added to the generated hba file. This allow to override configuration set by the initialization process. No defaults.
 - `PGPOOL_POSTGRES_CUSTOM_USERS`: List of comma or semicolon separeted list of postgres usernames. This will create entries in `pgpool_passwd`. No defaults.
 - `PGPOOL_POSTGRES_CUSTOM_PASSWORDS`: List of comma or semicolon separated list for postgresql user passwords. These are the corresponding passwords for the users in `PGPOOL_POSTGRES_CUSTOM_USERS`. No defaults.
 - `PGPOOL_AUTO_FAILBACK`: Enables pgpool `[auto_failback](https://www.pgpool.net/docs/latest/en/html/runtime-config-failover.html)`. Default to `no`.
@@ -428,6 +429,7 @@ Alternatively, you may also provide this configuration in your [custom](https://
 ## Configuration file
 
 You can override the default configuration by providing a configuration file. Set `PGPOOL_USER_CONF_FILE` with the path of the file, and this will be added to the default configuration.
+You can override the default hba configuration by providing a hba configuration file. Set `PGPOOL_USER_HBA_FILE` with the path of the file, and this will overwrite the default hba configuration.
 
 ## Step 1: Generate the configuration file.
 
@@ -438,7 +440,7 @@ max_pool='300'
 
 ### Step 2: Run the Pgpool image
 
-Run the Pgpool image, mounting a directory from your host and setting `PGPOOL_USER_CONF_FILE`. Using Docker Compose:
+Run the Pgpool image, mounting a directory from your host and setting `PGPOOL_USER_CONF_FILE` and `PGPOOL_USER_HBA_FILE`. Using Docker Compose:
 
 ```diff
      image: bitnami/pgpool:4
@@ -448,6 +450,7 @@ Run the Pgpool image, mounting a directory from your host and setting `PGPOOL_US
 +      - /path/to/myconf.conf:/config/myconf.conf
      environment:
 +      - PGPOOL_USER_CONF_FILE=/config/myconf.conf
++      - PGPOOL_USER_HBA_FILE=/config/hba.conf
        - PGPOOL_BACKEND_NODES=0:pg-0:5432,1:pg-1:5432
        - PGPOOL_SR_CHECK_USER=customuser
 ```

--- a/README.md
+++ b/README.md
@@ -447,11 +447,11 @@ Run the Pgpool image, mounting a directory from your host and setting `PGPOOL_US
      ports:
        - 5432:5432
 +    volumes:
- +      - /path/to/myconf.conf:/config/myconf.conf
- +      - /path/to/myhbaconf.conf:/config/myhbaconf.conf
-      environment:
- +      - PGPOOL_USER_CONF_FILE=/config/myconf.conf
- +      - PGPOOL_USER_HBA_FILE=/config/myhbaconf.conf
++      - /path/to/myconf.conf:/config/myconf.conf
++      - /path/to/myhbaconf.conf:/config/myhbaconf.conf
+     environment:
++      - PGPOOL_USER_CONF_FILE=/config/myconf.conf
++      - PGPOOL_USER_HBA_FILE=/config/myhbaconf.conf
        - PGPOOL_BACKEND_NODES=0:pg-0:5432,1:pg-1:5432
        - PGPOOL_SR_CHECK_USER=customuser
 ```

--- a/README.md
+++ b/README.md
@@ -447,10 +447,11 @@ Run the Pgpool image, mounting a directory from your host and setting `PGPOOL_US
      ports:
        - 5432:5432
 +    volumes:
-+      - /path/to/myconf.conf:/config/myconf.conf
-     environment:
-+      - PGPOOL_USER_CONF_FILE=/config/myconf.conf
-+      - PGPOOL_USER_HBA_FILE=/config/hba.conf
+ +      - /path/to/myconf.conf:/config/myconf.conf
+ +      - /path/to/myhbaconf.conf:/config/myhbaconf.conf
+      environment:
+ +      - PGPOOL_USER_CONF_FILE=/config/myconf.conf
+ +      - PGPOOL_USER_HBA_FILE=/config/myhbaconf.conf
        - PGPOOL_BACKEND_NODES=0:pg-0:5432,1:pg-1:5432
        - PGPOOL_SR_CHECK_USER=customuser
 ```


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add support for overwriting pool_hba.conf, similar to the mechanism for overwriting pgpool.conf.

**Benefits**

The user can customizethe pool_hba.conf.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

None
