### PR TITLE
update pgpool_healthcheck to not fail when backends are not available

### DIFF
--- a/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
+++ b/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
@@ -274,11 +274,11 @@ pgpool_healthcheck() {
         -h "${PGPOOL_TMP_DIR}" -p "${PGPOOL_PORT_NUMBER}" -tA -c "SHOW pool_nodes;" >/dev/null; then
         # look up backiends that are marked offline
         for node in $(PGPASSWORD="${PGPOOL_POSTGRES_PASSWORD}" psql -U "${PGPOOL_POSTGRES_USERNAME}" -d postgres \
-            -h "${PGPOOL_TMP_DIR}" -p "${PGPOOL_PORT_NUMBER}" -tA -c "SHOW pool_nodes;" | grep "down"); do
+            -h "${PGPOOL_TMP_DIR}" -p "${PGPOOL_PORT_NUMBER}" -tA -c "SHOW pool_nodes;" | grep "down" | tr -d ' ' ); do
             node_id=$(echo "${node}" | cut -d'|' -f1)
             node_host=$(echo "${node}" | cut -d'|' -f2)
-            if PGPASSWORD="${PGPOOL_POSTGRES_PASSWORD}" psql -U "${PGPOOL_POSTGRES_USERNAME}" -d postgres \
-                -h "${node_host}" -p "${PGPOOL_PORT_NUMBER}" -tA -c "SELECT 1" >/dev/null; then
+            if [[ $(PGCONNECT_TIMEOUT=3 PGPASSWORD="${PGPOOL_POSTGRES_PASSWORD}" psql -U "${PGPOOL_POSTGRES_USERNAME}" \
+                -d postgres -h "${node_host}" -p "${PGPOOL_PORT_NUMBER}" -tA -c "SELECT 1" || true) == 1 ]]; then
                 # attach backend if it has come back online
                 pgpool_attach_node "${node_id}"
             fi


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

update `pgpool_healthcheck` function and as a result `/opt/bitnami/scripts/pgpool/healthcheck.sh` to not fail when backends are not accessible with psql

**Benefits**

that makes it to be used as livenessProbe for pgpool k8s deployment and pod will go to CrashLoopBackOff

**Applicable issues**

https://github.com/bitnami/bitnami-docker-pgpool/issues/53
