### PR TITLE
Add ENV to support setting reserved_connections.

### DIFF
--- a/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
+++ b/4/debian-10/rootfs/opt/bitnami/scripts/libpgpool.sh
@@ -209,7 +209,7 @@ pgpool_validate() {
             print_validation_error "The values allowed for $yn are: yes or no"
         fi
     done
-    local positive_values=("PGPOOL_NUM_INIT_CHILDREN" "PGPOOL_MAX_POOL" "PGPOOL_CHILD_MAX_CONNECTIONS" "PGPOOL_CHILD_LIFE_TIME" "PGPOOL_CONNECTION_LIFE_TIME" "PGPOOL_CLIENT_IDLE_LIMIT" "PGPOOL_HEALTH_CHECK_PERIOD" "PGPOOL_HEALTH_CHECK_TIMEOUT" "PGPOOL_HEALTH_CHECK_MAX_RETRIES" "PGPOOL_HEALTH_CHECK_RETRY_DELAY")
+    local positive_values=("PGPOOL_NUM_INIT_CHILDREN" "PGPOOL_MAX_POOL" "PGPOOL_CHILD_MAX_CONNECTIONS" "PGPOOL_CHILD_LIFE_TIME" "PGPOOL_CONNECTION_LIFE_TIME" "PGPOOL_CLIENT_IDLE_LIMIT" "PGPOOL_HEALTH_CHECK_PERIOD" "PGPOOL_HEALTH_CHECK_TIMEOUT" "PGPOOL_HEALTH_CHECK_MAX_RETRIES" "PGPOOL_HEALTH_CHECK_RETRY_DELAY" "PGPOOL_RESERVED_CONNECTIONS")
     for p in "${positive_values[@]}"; do
         if [[ -n "${!p:-}" ]]; then
             if ! is_positive_int "${!p}"; then
@@ -445,6 +445,7 @@ pgpool_create_config() {
     # Connection Pooling settings
     # http://www.pgpool.net/docs/latest/en/html/runtime-config-connection-pooling.html
     [[ -n "${PGPOOL_NUM_INIT_CHILDREN:-}" ]] && pgpool_set_property "num_init_children" "$PGPOOL_NUM_INIT_CHILDREN"
+    [[ -n "${PGPOOL_RESERVED_CONNECTIONS:-}" ]] && pgpool_set_property "reserved_connections" "$PGPOOL_RESERVED_CONNECTIONS"
     pgpool_set_property "max_pool" "$PGPOOL_MAX_POOL"
     [[ -n "${PGPOOL_CHILD_MAX_CONNECTIONS:-}" ]] && pgpool_set_property "child_max_connections" "$PGPOOL_CHILD_MAX_CONNECTIONS"
     [[ -n "${PGPOOL_CHILD_LIFE_TIME:-}" ]] && pgpool_set_property "child_life_time" "$PGPOOL_CHILD_LIFE_TIME"

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Pgpool configuration:
 - `PGPOOL_ENABLE_POOL_PASSWD`: Whether to use a password file specified by `PGPOOL_PASSWD_FILE` for authentication. Defaults to `yes`.
 - `PGPOOL_PASSWD_FILE`: The password file for authentication. Defaults to `pool_passwd`.
 - `PGPOOL_NUM_INIT_CHILDREN`: The number of preforked Pgpool-II server processes. It is also the concurrent connections limit to Pgpool-II from clients. Defaults to `32`.
-- `PGPOOL_RESERVED_CONNECTIONS: When this parameter is set to 1 or greater, incoming connections from clients are not accepted with error message "Sorry, too many clients already", rather than blocked if the number of current connections from clients is more than (num_init_children - reserved_connections). Defaults to `0`.
+- `PGPOOL_RESERVED_CONNECTIONS`: When this parameter is set to 1 or greater, incoming connections from clients are not accepted with error message "Sorry, too many clients already", rather than blocked if the number of current connections from clients is more than (num_init_children - reserved_connections). Defaults to `0`.
 - `PGPOOL_MAX_POOL`: The maximum number of cached connections in each child process. Defaults to `15`.
 - `PGPOOL_CHILD_MAX_CONNECTIONS`: Specifies the lifetime of a Pgpool-II child process in terms of the number of client connections it can receive. Pgpool-II will terminate the child process after it has served child_max_connections client connections and will immediately spawn a new child process to take its place. Defaults to `0` which turns off the feature.
 - `PGPOOL_CHILD_LIFE_TIME`: The time in seconds to terminate a Pgpool-II child process if it remains idle. Defaults to `300`.

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Pgpool configuration:
 - `PGPOOL_ENABLE_POOL_PASSWD`: Whether to use a password file specified by `PGPOOL_PASSWD_FILE` for authentication. Defaults to `yes`.
 - `PGPOOL_PASSWD_FILE`: The password file for authentication. Defaults to `pool_passwd`.
 - `PGPOOL_NUM_INIT_CHILDREN`: The number of preforked Pgpool-II server processes. It is also the concurrent connections limit to Pgpool-II from clients. Defaults to `32`.
+- `PGPOOL_RESERVED_CONNECTIONS: When this parameter is set to 1 or greater, incoming connections from clients are not accepted with error message "Sorry, too many clients already", rather than blocked if the number of current connections from clients is more than (num_init_children - reserved_connections). Defaults to `0`.
 - `PGPOOL_MAX_POOL`: The maximum number of cached connections in each child process. Defaults to `15`.
 - `PGPOOL_CHILD_MAX_CONNECTIONS`: Specifies the lifetime of a Pgpool-II child process in terms of the number of client connections it can receive. Pgpool-II will terminate the child process after it has served child_max_connections client connections and will immediately spawn a new child process to take its place. Defaults to `0` which turns off the feature.
 - `PGPOOL_CHILD_LIFE_TIME`: The time in seconds to terminate a Pgpool-II child process if it remains idle. Defaults to `300`.
@@ -541,6 +542,7 @@ Please see the list of environment variables available in the Bitnami Pgpool con
 | PGPOOL_PASSWD_FILE                  | `pool_passwd` |
 | PGPOOL_MAX_POOL                     | `15`          |
 | PGPOOL_NUM_INIT_CHILDREN            | `32`          |
+| PGPOOL_RESERVED_CONNECTIONS         | `0`           |
 | PGPOOL_POSTGRES_CUSTOM_USERS        | nil           |
 | PGPOOL_POSTGRES_CUSTOM_PASSWORDS    | nil           |
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Enable setting reserved_connection in pgpool.conf via an ENV, similar to how, e.g. num_init_children is handled.

**Benefits**

This is to support a similar feature in the helm charts.

**Possible drawbacks**



**Applicable issues**

See [This comment](https://github.com/bitnami/charts/issues/6094#issuecomment-991395399) for context

**Additional information**

Needed for [This PR](https://github.com/bitnami/charts/pull/8398)
